### PR TITLE
Potential fix for code scanning alert no. 3: Useless regular-expression character escape

### DIFF
--- a/denops/mnh/main.ts
+++ b/denops/mnh/main.ts
@@ -27,9 +27,9 @@ export async function main(denops: Denops): Promise<void> {
       const secNumber = [0, 0, 0, 0, 0, 0];
       const contentNew = [];
       for (let i = 0; i < content.length; i++) {
-        if (content[i].match('^\s*?```')
-          || content[i].match('^\s*?{% highlight')
-          || content[i].match('^\s*?{% endhighlight')) {
+        if (content[i].match('^\\s*?```')
+          || content[i].match('^\\s*?{% highlight')
+          || content[i].match('^\\s*?{% endhighlight')) {
           // code block tag
           isInsideCodeblock = !isInsideCodeblock;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/i9wa4/vim-markdown-number-header/security/code-scanning/3](https://github.com/i9wa4/vim-markdown-number-header/security/code-scanning/3)

To fix the problem, we need to ensure that the `\s` escape sequence is correctly interpreted as a whitespace character in the regular expression. This can be achieved by using double backslashes (`\\s`) within the string literal to correctly escape the backslash character.

- Update the regular expressions on lines 30, 31, and 32 to use double backslashes (`\\s`) instead of single backslashes (`\s`).
- This change ensures that the regular expressions correctly match lines with optional leading whitespace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
