### PR TITLE
docs: add h6 heading level limitation to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ augroup mnh
   autocmd BufWritePost *.md execute 'NumberHeader'
 augroup END
 ```
+
+## 4. Limitations
+
+- Only headings up to h6 (`######`) are supported for numbering/renumbering.

--- a/doc/markdown-number-header.txt
+++ b/doc/markdown-number-header.txt
@@ -20,4 +20,9 @@ NumberHeader~
 
 	Number/Renumber markdown headings.
 
+==============================================================================
+LIMITATION                                   *markdown-number-header-limitation*
+
+	Only headings up to h6 (######) are supported for numbering/renumbering.
+
 vim: ft=help tw=78 et ts=2 sw=2 sts=2 norl


### PR DESCRIPTION
## Summary
- Added documentation about h6 heading level limitation
- Updated both README.md and help documentation

## Changes
- Added new "Limitations" section to README.md specifying that only headings up to h6 (`######`) are supported
- Added new "LIMITATION" section to doc/markdown-number-header.txt with the same information

## Test plan
- [x] Verify README.md displays the limitation correctly
- [x] Verify help documentation shows the limitation when viewed in Vim/Neovim

Closes #2